### PR TITLE
Fixed bug: Content Box & no Js

### DIFF
--- a/Quiz.html
+++ b/Quiz.html
@@ -37,8 +37,8 @@
 
     </section>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.7/dist/js/bootstrap.bundle.min.js" integrity="sha384-ndDqU0Gzau9qJ1lfW4pNLlhNTkCfHzAVBReH9diLvGRem5+R9g2FzA8ZGN954O5Q" crossorigin="anonymous"></script>
-    <script src="/js/script.js"></script>
-    <script src="js/quizQuestions.js"></script>
+    <script src="./js/script.js"></script>
+    <script src="./js/quizQuestions.js"></script>
 </body>
 
 </html>

--- a/index.html
+++ b/index.html
@@ -9,13 +9,13 @@
 </head>
 
 <body>
-    <nav>
-        <a href="#" class="nav_items">Home</a>
-        <a href="#" class="nav_items">About</a>
-        <a href="#" class="nav_items">Leaderboard</a>
-        <button id="mode-toggle">Light/Dark</button>
-    </nav>
     <header>
+        <nav>
+            <a href="#" class="nav_items">Home</a>
+            <a href="#" class="nav_items">About</a>
+            <a href="#" class="nav_items">Leaderboard</a>
+            <button id="mode-toggle">Light/Dark</button>
+        </nav>
         <h1>Quick Quiz Quest</h1>
         <p id="welcome-message"></p>
     </header>
@@ -39,12 +39,11 @@
                         style="background: #28a745; color: white; border: none; padding: 10px 20px; border-radius: 4px; cursor: pointer;">
                         Play as Guest
                     </button>
-
             </form>
         </div>
     </main>
 
-    <script src="/js/script.js"></script>
+    <script src="./js/script.js"></script>
 </body>
 
 </html>

--- a/style.css
+++ b/style.css
@@ -34,10 +34,9 @@ main {
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    height: 30vh;
+    height: 50vh;
     width: 30%;
     margin: auto;
-    border: #63C8FF 2px solid;
     border-radius: 25px;
     padding: 0px;
 }


### PR DESCRIPTION
The scripts for JS didn't have the relative path markers and adding them allowed for JS suppport to return

the content boxes were being shifted because the nav bar was outside and underneath the header so it was a header, nav, and then main which resulted in the messed up loaded screen.